### PR TITLE
HitboxComponent added

### DIFF
--- a/scenes/Projectile.tscn
+++ b/scenes/Projectile.tscn
@@ -1,13 +1,13 @@
-[gd_scene load_steps=4 format=3 uid="uid://itqgs2al1ybn"]
+[gd_scene load_steps=4 format=3 uid="uid://cmwtogcklr0f0"]
 
-[ext_resource type="Script" uid="uid://m8wljx2lb04b" path="res://scripts/objects/projectile.gd" id="1_dprbf"]
-[ext_resource type="Texture2D" uid="uid://b8cljx30m6u2h" path="res://resources/sprites/projectiles/projectile.png" id="2_vihyi"]
+[ext_resource type="Script" uid="uid://m8wljx2lb04b" path="res://scripts/objects/projectile.gd" id="1_q3m7n"]
+[ext_resource type="Texture2D" uid="uid://b8cljx30m6u2h" path="res://resources/sprites/projectiles/projectile.png" id="2_softn"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_kdm4f"]
 radius = 5.0
 
 [node name="Projectile" type="Area2D"]
-script = ExtResource("1_dprbf")
+script = ExtResource("1_q3m7n")
 rotation_deg = 30.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -15,4 +15,4 @@ shape = SubResource("CircleShape2D_kdm4f")
 
 [node name="Sprite" type="Sprite2D" parent="."]
 scale = Vector2(-0.015, -0.015)
-texture = ExtResource("2_vihyi")
+texture = ExtResource("2_softn")

--- a/scenes/components/hitbox_component.tscn
+++ b/scenes/components/hitbox_component.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3 uid="uid://ctpib5py0hd2d"]
+
+[ext_resource type="Script" uid="uid://cqpkef73vsssu" path="res://scripts/components/hitbox_component.gd" id="1_okvui"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_5rxpd"]
+
+[node name="HitboxComponent" type="Area2D"]
+script = ExtResource("1_okvui")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_5rxpd")
+debug_color = Color(0.980392, 0, 0, 0.419608)

--- a/scenes/projectile.tscn
+++ b/scenes/projectile.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://itqgs2al1ybn"]
+[gd_scene load_steps=4 format=3 uid="uid://cmwtogcklr0f0"]
 
 [ext_resource type="Script" uid="uid://m8wljx2lb04b" path="res://scripts/objects/projectile.gd" id="1_q3m7n"]
 [ext_resource type="Texture2D" uid="uid://b8cljx30m6u2h" path="res://resources/sprites/projectiles/projectile.png" id="2_softn"]

--- a/scripts/components/hitbox_component.gd
+++ b/scripts/components/hitbox_component.gd
@@ -1,0 +1,13 @@
+extends Area2D
+class_name HitboxComponent
+@export var health_comp : HealthComponent
+@export var can_get_hit : bool
+@export var can_heal : bool
+
+
+func _on_area_entered(area: Area2D) -> void:
+	if health_comp != null:
+		if can_get_hit == true and area is Projectile:
+			health_comp.apply_damage(area.damage)
+		if can_heal == true and area is HealthPickup:
+			health_comp.apply_heal(area.hp)

--- a/scripts/components/hitbox_component.gd.uid
+++ b/scripts/components/hitbox_component.gd.uid
@@ -1,0 +1,1 @@
+uid://cqpkef73vsssu


### PR DESCRIPTION
HitboxComponent add that monitors collisions with 2 types of objects: Proyectiles and HealthPickups
- Added script to scene
- HealthComponent can be assigned
- Added function that, if there is a HealthComponent assigned, scans when an Area2D collides with it and checks the class of the area
- After checking the class, it calls a HealthComponent function accordingly